### PR TITLE
cmd/tlsconfig: remove support for deprecated tls.VersionSSL30 (#412)

### DIFF
--- a/cmd/tlsconfig/tls_version_go11.go
+++ b/cmd/tlsconfig/tls_version_go11.go
@@ -1,0 +1,31 @@
+// +build !go1.12
+
+// This file can be removed once go1.11 is no longer supported
+
+package main
+
+import (
+	"crypto/tls"
+	"sort"
+)
+
+func mapTLSVersions(tlsVersions []string) []int {
+	var versions []int
+	for _, tlsVersion := range tlsVersions {
+		switch tlsVersion {
+		case "TLSv1.2":
+			versions = append(versions, tls.VersionTLS12)
+		case "TLSv1.1":
+			versions = append(versions, tls.VersionTLS11)
+		case "TLSv1":
+			versions = append(versions, tls.VersionTLS10)
+		case "SSLv3":
+			// unsupported from go1.14
+			versions = append(versions, tls.VersionSSL30)
+		default:
+			continue
+		}
+	}
+	sort.Ints(versions)
+	return versions
+}

--- a/cmd/tlsconfig/tls_version_go12_go13.go
+++ b/cmd/tlsconfig/tls_version_go12_go13.go
@@ -1,0 +1,33 @@
+// +build go1.12,!go1.14
+
+// This file can be removed once go1.13 is no longer supported
+
+package main
+
+import (
+	"crypto/tls"
+	"sort"
+)
+
+func mapTLSVersions(tlsVersions []string) []int {
+	var versions []int
+	for _, tlsVersion := range tlsVersions {
+		switch tlsVersion {
+		case "TLSv1.3":
+			versions = append(versions, tls.VersionTLS13)
+		case "TLSv1.2":
+			versions = append(versions, tls.VersionTLS12)
+		case "TLSv1.1":
+			versions = append(versions, tls.VersionTLS11)
+		case "TLSv1":
+			versions = append(versions, tls.VersionTLS10)
+		case "SSLv3":
+			// unsupported from go1.14
+			versions = append(versions, tls.VersionSSL30)
+		default:
+			continue
+		}
+	}
+	sort.Ints(versions)
+	return versions
+}

--- a/cmd/tlsconfig/tls_version_go14.go
+++ b/cmd/tlsconfig/tls_version_go14.go
@@ -1,0 +1,29 @@
+// +build go1.14 !go1.11
+
+// main
+package main
+
+import (
+	"crypto/tls"
+	"sort"
+)
+
+func mapTLSVersions(tlsVersions []string) []int {
+	var versions []int
+	for _, tlsVersion := range tlsVersions {
+		switch tlsVersion {
+		case "TLSv1.3":
+			versions = append(versions, tls.VersionTLS13)
+		case "TLSv1.2":
+			versions = append(versions, tls.VersionTLS12)
+		case "TLSv1.1":
+			versions = append(versions, tls.VersionTLS11)
+		case "TLSv1":
+			versions = append(versions, tls.VersionTLS10)
+		default:
+			continue
+		}
+	}
+	sort.Ints(versions)
+	return versions
+}

--- a/cmd/tlsconfig/tlsconfig.go
+++ b/cmd/tlsconfig/tlsconfig.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -14,7 +13,6 @@ import (
 	"log"
 	"net/http"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/mozilla/tls-observatory/constants"
@@ -110,28 +108,6 @@ func getGoCipherConfig(name string, sstls ServerSideTLSJson) (goCipherConfigurat
 		return cipherConf, fmt.Errorf("No TLS versions found for configuration '%s'", name)
 	}
 	return cipherConf, nil
-}
-
-func mapTLSVersions(tlsVersions []string) []int {
-	var versions []int
-	for _, tlsVersion := range tlsVersions {
-		switch tlsVersion {
-		case "TLSv1.3":
-			versions = append(versions, tls.VersionTLS13)
-		case "TLSv1.2":
-			versions = append(versions, tls.VersionTLS12)
-		case "TLSv1.1":
-			versions = append(versions, tls.VersionTLS11)
-		case "TLSv1":
-			versions = append(versions, tls.VersionTLS10)
-		case "SSLv3":
-			versions = append(versions, tls.VersionSSL30)
-		default:
-			continue
-		}
-	}
-	sort.Ints(versions)
-	return versions
 }
 
 func getGoTLSConf() (goTLSConfiguration, error) {


### PR DESCRIPTION
* cmd/tlsconfig: build tags to deprecate tls.VersionSSL30 from go1.14

* cmd/tlsconfig: build tags to turn off TLSv1.3 in go1.11